### PR TITLE
Update to ensure CUDA is installed

### DIFF
--- a/pip/cuda_requirements.txt
+++ b/pip/cuda_requirements.txt
@@ -6,7 +6,7 @@
 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 -f https://data.dgl.ai/wheels/cu118/repo.html
 
-tensorflow==2.14.0
+tensorflow[and-cuda]~=2.14.0
 
 tensorrt
 
@@ -14,7 +14,7 @@ torch==2.0.1
 torch_geometric
 lightning
 
-jax[cuda11_pip]==0.4.16
+jax~=0.4.16
 
 dgl==1.1.2
 dgllife


### PR DESCRIPTION
- Fixes #60 

After I was unable to find the GPU device in pFDA, I tried to see if this worked locally:

![Screenshot from 2024-08-26 12-55-23](https://github.com/user-attachments/assets/111b6339-953f-4e5a-b186-732098b0c5c9)

So it turns out the docker container is missing some CUDA libraries which allow it to communicate and register the GPU. After the changes in this PR, I was able to get GPU working inside docker:

![Screenshot from 2024-08-27 17-08-01](https://github.com/user-attachments/assets/14186bff-7389-4c76-a9a3-998ec4c7e388)

You can see the warning messages still appear, but I am able to find the GPU device